### PR TITLE
feat: パスベースルーティングへの切り替え（/admin で管理画面）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,30 +3,23 @@ import ReceptionApp from './pages/reception/ReceptionApp'
 import AdminApp from './pages/admin/AdminApp'
 
 /**
- * カスタムドメイン（サブドメイン）によって
- * 見せる画面（受付 / 管理）を振り分けるためのルートコンポーネントです。
- * （ローカル開発時はパスによってルーティングします）
+ * パスベースルーティングにより、受付画面と管理画面を振り分けるルートコンポーネント。
+ *
+ * - `/`      → 受付画面（ReceptionApp）
+ * - `/admin` → 管理画面（AdminApp）
+ *
+ * ※カスタムドメイン導入後はサブドメイン方式に切り替え可能
+ *   （例: reception.example.com / admin.example.com）
  */
 function App() {
-  const hostname = window.location.hostname
-  const isAdminDomain = hostname.startsWith('admin.')
-
-  // サブドメインが 'admin.' の場合は管理画面へ、それ以外は受付画面へ
-  if (isAdminDomain) {
-    return (
-      <BrowserRouter>
-        <Routes>
-          <Route path="/*" element={<AdminApp />} />
-        </Routes>
-      </BrowserRouter>
-    )
-  }
-
-  // 受付アプリ（reception.* または localhost）
   return (
     <BrowserRouter>
       <Routes>
+        {/* 受付画面 */}
         <Route path="/" element={<ReceptionApp />} />
+        {/* 管理画面 */}
+        <Route path="/admin/*" element={<AdminApp />} />
+        {/* その他のパスは受付画面へリダイレクト */}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
@@ -34,3 +27,4 @@ function App() {
 }
 
 export default App
+


### PR DESCRIPTION
Closes #25

## 変更内容
- App.tsx のルーティングをサブドメイン判定からパスベースに変更
  - `/` → 受付画面
  - `/admin` → 管理画面
- カスタムドメイン導入時にサブドメイン方式へ戻す選択肢をコメントで記載

## 理由
CloudFrontデフォルトURL（`d2xr7jx92fio.cloudfront.net`）ではサブドメインが使えないため。