### PR TITLE
feat: フロントエンドとバックエンドAPIの実接続

### DIFF
--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -1,0 +1,122 @@
+/**
+ * 顔写真登録システム APIクライアント
+ */
+
+const API_BASE = '/v1' // CloudFrontでの同ドメインプロキシ、ローカルDevサーバプロキシを利用
+
+export type InitializeUploadResponse = {
+  upload_url: string
+  fields: Record<string, string>
+  photo_key: string
+  entry_id: string
+}
+
+export type RegisterEntryRequest = {
+  company_name: string
+  visitor_name: string
+  purpose: string
+  purpose_detail?: string
+  photo_key: string
+}
+
+export type Entry = {
+  id: string
+  pk: string
+  sk: string
+  created_at: string
+  company_name: string
+  visitor_name: string
+  purpose: string
+  purpose_detail: string
+  photo_url: string | null
+  expires_at: number
+}
+
+export const apiClient = {
+  /**
+   * S3 Presigned URLの発行
+   */
+  async initializeUpload(filename: string, contentType: string): Promise<InitializeUploadResponse> {
+    const res = await fetch(`${API_BASE}/entries/initialize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        photo_filename: filename,
+        photo_content_type: contentType
+      })
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`Failed to initialize upload: ${text}`)
+    }
+    return res.json()
+  },
+
+  /**
+   * S3への画像アップロード
+   */
+  async uploadPhotoToS3(presignedData: InitializeUploadResponse, file: Blob): Promise<void> {
+    const formData = new FormData()
+    // Presigned PostのfieldsをすべてFormDataに追加する必要がある
+    Object.entries(presignedData.fields).forEach(([key, value]) => {
+      formData.append(key, value)
+    })
+    // 最後にfileを追加する（S3 POST Policyの仕様上、fileは最後尾推奨）
+    formData.append('file', file)
+
+    const res = await fetch(presignedData.upload_url, {
+      method: 'POST',
+      body: formData
+    })
+    
+    if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Failed to upload photo to S3: ${text}`)
+    }
+  },
+
+  /**
+   * エントリーの登録 (DynamoDB)
+   */
+  async registerEntry(data: RegisterEntryRequest): Promise<Entry> {
+    const res = await fetch(`${API_BASE}/entries`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })
+    if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Failed to register entry: ${text}`)
+    }
+    return res.json()
+  },
+
+  /**
+   * エントリーの一覧取得（管理画面用）
+   */
+  async listEntries(): Promise<Entry[]> {
+    const res = await fetch(`${API_BASE}/admin/entries`, {
+      method: 'GET'
+    })
+    if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Failed to fetch entries: ${text}`)
+    }
+    return res.json()
+  },
+
+  /**
+   * エントリーの一括削除（管理画面用）
+   */
+  async bulkDeleteEntries(items: { id: string; photo_url: string | null }[]): Promise<void> {
+    const res = await fetch(`${API_BASE}/admin/entries/bulk-delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items })
+    })
+    if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Failed to bulk delete entries: ${text}`)
+    }
+  }
+}

--- a/frontend/src/pages/admin/AdminApp.tsx
+++ b/frontend/src/pages/admin/AdminApp.tsx
@@ -1,26 +1,10 @@
-import { useState } from 'react'
-import { Search, Download, Trash2, LogOut, CheckSquare, Image as ImageIcon } from 'lucide-react'
+import React, { useState, useEffect } from 'react'
+import { Search, Download, Trash2, LogOut, CheckSquare, Image as ImageIcon, Loader2 } from 'lucide-react'
+import { apiClient } from '../../api/apiClient'
+import type { Entry } from '../../api/apiClient'
 
-// --- モックデータ定義 ---
-type AdminEntry = {
-  id: string
-  created_at: string
-  company_name: string
-  visitor_name: string
-  purpose: string
-  photo_url: string | null
-}
+const ITEMS_PER_PAGE = 15
 
-const mockEntries: AdminEntry[] = Array.from({ length: 15 }).map((_, i) => ({
-  id: `ENTRY-${1000 + i}`,
-  created_at: new Date(Date.now() - i * 3600000).toLocaleString('ja-JP'),
-  company_name: i % 3 === 0 ? '株式会社テスト' : 'サンプル有限会社',
-  visitor_name: `ゲスト 太郎 ${i}`,
-  purpose: i % 2 === 0 ? '商談' : '面接',
-  photo_url: null, // UI確認用
-}))
-
-// --- コンポーネント本体 ---
 export default function AdminApp() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   
@@ -29,13 +13,19 @@ export default function AdminApp() {
   const [password, setPassword] = useState('')
 
   // ダッシュボード状態
-  const [entries] = useState<AdminEntry[]>(mockEntries)
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [searchQuery, setSearchQuery] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
 
-  // 簡易ログイン処理
+  // 簡易ログイン処理 (複数ID対応)
   const handleLogin = (e: React.FormEvent) => {
     e.preventDefault()
+    // 簡易認証: ユーザーIDとパスワードが入力されていれば許可
+    // 本格的な認証 (Cognito等) は別Issueで対応
     if (userId && password) {
       setIsLoggedIn(true)
     }
@@ -46,15 +36,67 @@ export default function AdminApp() {
     setIsLoggedIn(false)
     setUserId('')
     setPassword('')
+    setEntries([])
+    setSelectedIds(new Set())
   }
+
+  // エントリー一覧の取得
+  const fetchEntries = async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await apiClient.listEntries()
+      setEntries(data)
+    } catch (err) {
+      console.error(err)
+      setError('データの取得に失敗しました。')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // ログイン成功時に一覧を取得
+  useEffect(() => {
+    if (isLoggedIn) {
+      fetchEntries()
+    }
+  }, [isLoggedIn])
+
+  // 検索・フィルタリング
+  const filteredEntries = entries.filter(e => {
+    if (!searchQuery) return true
+    const q = searchQuery.toLowerCase()
+    return (
+      e.company_name.toLowerCase().includes(q) ||
+      e.visitor_name.toLowerCase().includes(q) ||
+      e.purpose.toLowerCase().includes(q) ||
+      (e.purpose_detail || '').toLowerCase().includes(q)
+    )
+  })
+
+  // ページネーション計算
+  const totalPages = Math.ceil(filteredEntries.length / ITEMS_PER_PAGE) || 1
+  // 検索等でページ数が減った場合の補正
+  if (currentPage > totalPages && totalPages > 0) {
+    setCurrentPage(totalPages)
+  }
+  const paginatedEntries = filteredEntries.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  )
 
   // チェックボックス操作
   const toggleSelectAll = () => {
-    if (selectedIds.size === entries.length) {
-      setSelectedIds(new Set())
+    const pageIds = paginatedEntries.map(e => e.id)
+    const allSelected = pageIds.length > 0 && pageIds.every(id => selectedIds.has(id))
+    
+    const newSet = new Set(selectedIds)
+    if (allSelected) {
+      pageIds.forEach(id => newSet.delete(id))
     } else {
-      setSelectedIds(new Set(entries.map(e => e.id)))
+      pageIds.forEach(id => newSet.add(id))
     }
+    setSelectedIds(newSet)
   }
 
   const toggleSelectLine = (id: string) => {
@@ -62,6 +104,61 @@ export default function AdminApp() {
     if (newSet.has(id)) newSet.delete(id)
     else newSet.add(id)
     setSelectedIds(newSet)
+  }
+  
+  const isAllCurrentPageSelected = paginatedEntries.length > 0 && paginatedEntries.every(e => selectedIds.has(e.id))
+
+  // 削除処理 (単一・複数)
+  const handleDelete = async (itemsToDelete: {id: string, photo_url: string | null}[]) => {
+    if (!window.confirm(`${itemsToDelete.length}件のデータを削除します。よろしいですか？`)) return
+    
+    try {
+      setIsLoading(true)
+      await apiClient.bulkDeleteEntries(itemsToDelete)
+      // 再取得
+      await fetchEntries()
+      // 削除されたIDを選択状態から解除
+      const newSelected = new Set(selectedIds)
+      itemsToDelete.forEach(i => newSelected.delete(i.id))
+      setSelectedIds(newSelected)
+    } catch (err) {
+      console.error(err)
+      alert('削除に失敗しました。')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // 個別画像のダウンロード処理
+  const handleDownloadImage = async (url: string, filename: string) => {
+    try {
+      const res = await fetch(url)
+      const blob = await res.blob()
+      const blobUrl = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = blobUrl
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      window.URL.revokeObjectURL(blobUrl)
+    } catch (err) {
+      console.error(err)
+      // CORS等でfetchできない場合のフォールバック
+      window.open(url, '_blank')
+    }
+  }
+
+  // フォーマット用: 日時整形
+  const formatDateTime = (isoString: string) => {
+    try {
+      return new Date(isoString).toLocaleString('ja-JP', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit'
+      })
+    } catch {
+      return isoString
+    }
   }
 
   // ログイン画面表示
@@ -117,18 +214,30 @@ export default function AdminApp() {
           </div>
           <h1 className="text-xl font-bold text-gray-900">顔写真登録 管理ダッシュボード</h1>
         </div>
-        <button
-          onClick={handleLogout}
-          className="flex items-center gap-2 text-sm text-gray-600 hover:text-red-600 transition-colors"
-        >
-          <LogOut className="w-4 h-4" />
-          ログアウト
-        </button>
+        <div className="flex items-center gap-4">
+          <span className="text-sm font-medium text-gray-600 bg-gray-100 px-3 py-1 rounded-full">
+            👤 {userId}
+          </span>
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 text-sm text-gray-600 hover:text-red-600 transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+            ログアウト
+          </button>
+        </div>
       </header>
 
       {/* Main Content */}
       <main className="flex-1 max-w-7xl w-full mx-auto p-6 space-y-6">
         
+        {/* Error Alert */}
+        {error && (
+          <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-md">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
         {/* Search & Filter Section */}
         <section className="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
           <div className="flex flex-col md:flex-row gap-4 items-end">
@@ -143,16 +252,29 @@ export default function AdminApp() {
                   placeholder="会社名、名前、用件で絞り込み..."
                   className="pl-10 w-full rounded-md border border-gray-300 py-2.5 shadow-sm focus:border-[var(--primary)] focus:ring-1 focus:ring-[var(--primary)]"
                   value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
+                  onChange={e => {
+                    setSearchQuery(e.target.value)
+                    setCurrentPage(1) // 検索時は1ページ目に戻す
+                  }}
                 />
               </div>
             </div>
             <div className="flex gap-2 w-full md:w-auto">
-              <button className="px-4 py-2.5 bg-gray-100 text-gray-700 border border-gray-300 rounded-md hover:bg-gray-200 font-medium text-sm transition-colors whitespace-nowrap">
+              <button 
+                onClick={() => {
+                  setSearchQuery('')
+                  setCurrentPage(1)
+                }}
+                className="px-4 py-2.5 bg-gray-100 text-gray-700 border border-gray-300 rounded-md hover:bg-gray-200 font-medium text-sm transition-colors whitespace-nowrap"
+              >
                 クリア
               </button>
-              <button className="px-6 py-2.5 bg-gray-800 text-white rounded-md hover:bg-gray-900 font-medium text-sm transition-colors whitespace-nowrap">
-                検索
+              <button 
+                onClick={fetchEntries}
+                className="flex items-center gap-2 px-6 py-2.5 bg-gray-800 text-white rounded-md hover:bg-gray-900 font-medium text-sm transition-colors whitespace-nowrap"
+              >
+                {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
+                再読み込み
               </button>
             </div>
           </div>
@@ -168,24 +290,34 @@ export default function AdminApp() {
             </div>
             <div className="flex gap-2">
               <button 
-                disabled={selectedIds.size === 0}
-                className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm transition-colors"
+                disabled={true} // ZIPダウンロードは別Issueで対応
+                title="現在ZIP一括ダウンロードは開発中です"
+                className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-md text-sm text-gray-400 cursor-not-allowed shadow-sm transition-colors"
               >
                 <Download className="w-4 h-4" />
-                ZIP一括ダウンロード
+                ZIP一括DL (準備中)
               </button>
               <button 
-                disabled={selectedIds.size === 0}
+                disabled={selectedIds.size === 0 || isLoading}
+                onClick={() => {
+                  const targets = entries.filter(e => selectedIds.has(e.id)).map(e => ({ id: e.id, photo_url: e.photo_url }))
+                  handleDelete(targets)
+                }}
                 className="flex items-center gap-2 px-4 py-2 bg-white border border-red-200 text-red-600 rounded-md text-sm hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm transition-colors"
               >
                 <Trash2 className="w-4 h-4" />
-                削除
+                一括削除
               </button>
             </div>
           </div>
 
           {/* Data Table */}
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto relative min-h-[300px]">
+            {isLoading && entries.length === 0 && (
+               <div className="absolute inset-0 flex items-center justify-center bg-white/50 z-10">
+                 <Loader2 className="w-8 h-8 animate-spin text-[var(--primary)]" />
+               </div>
+            )}
             <table className="w-full text-left border-collapse text-sm">
               <thead className="bg-white border-b-2 border-gray-200 text-gray-500 uppercase font-semibold">
                 <tr>
@@ -193,8 +325,9 @@ export default function AdminApp() {
                     <input 
                       type="checkbox" 
                       className="rounded border-gray-300 text-[var(--primary)] focus:ring-[var(--primary)]"
-                      checked={selectedIds.size > 0 && selectedIds.size === entries.length}
+                      checked={isAllCurrentPageSelected}
                       onChange={toggleSelectAll}
+                      disabled={paginatedEntries.length === 0}
                     />
                   </th>
                   <th className="p-4 whitespace-nowrap">登録日時</th>
@@ -205,8 +338,8 @@ export default function AdminApp() {
                   <th className="p-4 text-center w-24">操作</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
-                {entries.map(entry => (
+              <tbody className="divide-y divide-gray-100 relative">
+                {paginatedEntries.map(entry => (
                   <tr key={entry.id} className="hover:bg-gray-50 transition-colors">
                     <td className="p-4 text-center">
                       <input 
@@ -216,39 +349,70 @@ export default function AdminApp() {
                         onChange={() => toggleSelectLine(entry.id)}
                       />
                     </td>
-                    <td className="p-4 text-gray-500 whitespace-nowrap">{entry.created_at}</td>
+                    <td className="p-4 text-gray-500 whitespace-nowrap">
+                      {formatDateTime(entry.created_at)}
+                    </td>
                     <td className="p-4 text-center">
-                      <div className="w-10 h-10 mx-auto rounded bg-gray-100 flex items-center justify-center border border-gray-200 overflow-hidden cursor-pointer hover:border-[var(--primary)] transition-colors">
+                      <div className="w-10 h-10 mx-auto rounded bg-gray-100 flex items-center justify-center border border-gray-200 overflow-hidden">
                         {entry.photo_url ? (
-                          <img src={entry.photo_url} alt="Face" className="w-full h-full object-cover" />
+                          <a href={entry.photo_url} target="_blank" rel="noopener noreferrer" className="w-full h-full block">
+                            <img src={entry.photo_url} alt="Face" className="w-full h-full object-cover hover:opacity-80 transition-opacity" />
+                          </a>
                         ) : (
                           <ImageIcon className="w-4 h-4 text-gray-400" />
                         )}
                       </div>
                     </td>
-                    <td className="p-4 font-medium text-gray-900">{entry.company_name}</td>
-                    <td className="p-4 text-gray-700">{entry.visitor_name}</td>
+                    <td className="p-4 font-medium text-gray-900 truncate max-w-[150px]" title={entry.company_name}>
+                      {entry.company_name}
+                    </td>
+                    <td className="p-4 text-gray-700 truncate max-w-[150px]" title={entry.visitor_name}>
+                      {entry.visitor_name}
+                    </td>
                     <td className="p-4 text-gray-600">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
-                        {entry.purpose}
-                      </span>
+                      <div className="flex flex-col gap-1 items-start">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 whitespace-nowrap">
+                          {entry.purpose}
+                        </span>
+                        {entry.purpose_detail && (
+                          <span className="text-xs text-gray-500 truncate max-w-[120px]" title={entry.purpose_detail}>
+                            {entry.purpose_detail}
+                          </span>
+                        )}
+                      </div>
                     </td>
                     <td className="p-4 text-center">
-                      <div className="flex justify-center gap-2">
-                        <button className="text-gray-400 hover:text-[var(--primary)] transition-colors" title="ダウンロード">
+                      <div className="flex justify-center gap-3">
+                        <button 
+                          onClick={() => {
+                            if (entry.photo_url) {
+                              const ext = entry.photo_url.split('.').pop() || 'jpg'
+                              const filename = `${entry.company_name}_${entry.visitor_name}_${entry.id.substring(0,6)}.${ext}`
+                              handleDownloadImage(entry.photo_url, filename)
+                            }
+                          }}
+                          disabled={!entry.photo_url}
+                          className="text-gray-400 hover:text-[var(--primary)] transition-colors disabled:opacity-30 disabled:hover:text-gray-400" 
+                          title="ダウンロード"
+                        >
                           <Download className="w-4 h-4" />
                         </button>
-                        <button className="text-gray-400 hover:text-red-500 transition-colors" title="削除">
+                        <button 
+                          onClick={() => handleDelete([{id: entry.id, photo_url: entry.photo_url}])}
+                          disabled={isLoading}
+                          className="text-gray-400 hover:text-red-500 transition-colors disabled:opacity-30" 
+                          title="削除"
+                        >
                           <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
                     </td>
                   </tr>
                 ))}
-                {entries.length === 0 && (
+                {!isLoading && paginatedEntries.length === 0 && (
                   <tr>
                     <td colSpan={7} className="p-8 text-center text-gray-500">
-                      登録されたデータはありません
+                      一致するデータがありません
                     </td>
                   </tr>
                 )}
@@ -259,13 +423,48 @@ export default function AdminApp() {
           {/* Pagination */}
           <div className="px-6 py-4 border-t border-gray-200 bg-white flex items-center justify-between">
             <span className="text-sm text-gray-500">
-              全 <span className="font-semibold text-gray-900">{entries.length}</span> 件中 1-15 件を表示
+              全 <span className="font-semibold text-gray-900">{filteredEntries.length}</span> 件中 
+              {filteredEntries.length > 0 ? ` ${(currentPage - 1) * ITEMS_PER_PAGE + 1}-${Math.min(currentPage * ITEMS_PER_PAGE, filteredEntries.length)} ` : ' 0 '} 
+              件を表示
             </span>
             <div className="flex gap-1">
-              <button disabled className="px-3 py-1 border border-gray-300 rounded text-sm text-gray-500 bg-gray-50 disabled:opacity-50">前へ</button>
-              <button className="px-3 py-1 border border-[var(--primary)] bg-[var(--primary)] rounded text-sm text-white font-medium">1</button>
-              <button className="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50">2</button>
-              <button className="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50">次へ</button>
+              <button 
+                disabled={currentPage <= 1 || isLoading}
+                onClick={() => setCurrentPage(p => p - 1)}
+                className="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:bg-gray-50"
+              >
+                前へ
+              </button>
+              
+              {Array.from({ length: totalPages }, (_, i) => i + 1)
+                // ページ数が多い場合は省略が必要だが、今回は簡易的に全ページ表示か、最大5ページ程度に絞る
+                .filter(page => Math.abs(page - currentPage) <= 2 || page === 1 || page === totalPages)
+                .map((page, index, array) => (
+                  <React.Fragment key={page}>
+                    {index > 0 && array[index - 1] !== page - 1 && (
+                      <span className="px-2 py-1 text-gray-400">...</span>
+                    )}
+                    <button 
+                      onClick={() => setCurrentPage(page)}
+                      disabled={isLoading}
+                      className={`px-3 py-1 border rounded text-sm font-medium transition-colors ${
+                        currentPage === page 
+                          ? 'border-[var(--primary)] bg-[var(--primary)] text-white' 
+                          : 'border-gray-300 text-gray-700 bg-white hover:bg-gray-50'
+                      }`}
+                    >
+                      {page}
+                    </button>
+                  </React.Fragment>
+                ))}
+              
+              <button 
+                disabled={currentPage >= totalPages || isLoading}
+                onClick={() => setCurrentPage(p => p + 1)}
+                className="px-3 py-1 border border-gray-300 rounded text-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:bg-gray-50"
+              >
+                次へ
+              </button>
             </div>
           </div>
         </section>

--- a/frontend/src/pages/reception/ReceptionApp.tsx
+++ b/frontend/src/pages/reception/ReceptionApp.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react'
 import { Camera, Upload, RefreshCw, CheckCircle2 } from 'lucide-react'
+import { apiClient } from '../../api/apiClient'
 
 type EntryFormData = {
   company_name: string
@@ -79,26 +80,52 @@ export default function ReceptionApp() {
     }
   }
 
-  // フォーム送信（モック）とキオスクリセット
+  // フォーム送信
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!photoPreview || !formData.company_name || !formData.visitor_name) return
 
     setIsSubmitting(true)
 
-    // TODO: ここで S3 Presigned URL 取得 -> S3 画像アップロード -> DynamoDB 登録 API を呼び出す
-    // 今回はモックとして2秒待機
-    await new Promise(resolve => setTimeout(resolve, 2000))
+    try {
+      // 1. DataURLからBlobを生成
+      const res = await fetch(photoPreview)
+      const blob = await res.blob()
+      
+      // MIMEタイプから拡張子を決定
+      const mimeType = blob.type || 'image/jpeg'
+      const ext = mimeType.split('/')[1] || 'jpeg'
+      const filename = `photo.${ext}`
 
-    setIsSubmitting(false)
-    setIsSuccess(true)
+      // 2. S3 Presigned URL 取得
+      const initData = await apiClient.initializeUpload(filename, mimeType)
 
-    // キオスクモード: 3秒後に自動リセット
-    setTimeout(() => {
-      setFormData(INITIAL_FORM_DATA)
-      setPhotoPreview(null)
-      setIsSuccess(false)
-    }, 3000)
+      // 3. S3 画像アップロード
+      await apiClient.uploadPhotoToS3(initData, blob)
+
+      // 4. DynamoDB 登録
+      await apiClient.registerEntry({
+        company_name: formData.company_name,
+        visitor_name: formData.visitor_name,
+        purpose: formData.purpose,
+        purpose_detail: formData.purpose_detail,
+        photo_key: initData.photo_key
+      })
+
+      setIsSuccess(true)
+
+      // キオスクモード: 3秒後に自動リセット
+      setTimeout(() => {
+        setFormData(INITIAL_FORM_DATA)
+        setPhotoPreview(null)
+        setIsSuccess(false)
+      }, 3000)
+    } catch (err) {
+      console.error('Registration failed:', err)
+      alert(`登録に失敗しました。もう一度お試しください。\n詳細: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   // 完了画面

--- a/frontend/tests/admin.spec.ts
+++ b/frontend/tests/admin.spec.ts
@@ -2,23 +2,25 @@ import { test, expect } from '@playwright/test';
 
 test.describe('管理画面ダッシュボード', () => {
   test.beforeEach(async ({ page }) => {
-    // admin.localhost でアクセスし管理画面を表示
-    // DNS解決できない場合は受付画面が表示されるためスキップ
-    try {
-      await page.goto('http://admin.localhost:5173/');
-    } catch {
-      await page.goto('/');
-    }
+    // APIレスポンスをモック化して、バックエンドなしでもUIテストが通るようにする
+    await page.route('**/v1/admin/entries', async route => {
+      const json = [
+        {
+          id: 'ENTRY-MOCK-1',
+          created_at: new Date().toISOString(),
+          company_name: '株式会社Playwrightモック',
+          visitor_name: 'テスト ユーザー',
+          purpose: '商談',
+          photo_url: null
+        }
+      ];
+      await route.fulfill({ json });
+    });
+
+    await page.goto('/admin');
   });
 
   test('ログイン画面が表示され、ログイン後にダッシュボードが見えること', async ({ page }) => {
-    const heading = page.locator('h1');
-    const text = await heading.textContent();
-
-    if (text?.includes('受付システム')) {
-      test.skip(true, 'admin サブドメイン未解決のためスキップ');
-    }
-
     // --- ログイン画面の検証 ---
     await expect(page.getByRole('heading', { name: '顔写真登録システム 管理者用' })).toBeVisible();
     await page.fill('input[type="text"]', 'admin');
@@ -27,10 +29,10 @@ test.describe('管理画面ダッシュボード', () => {
 
     // --- ダッシュボード検証 ---
     await expect(page.getByRole('heading', { name: '顔写真登録 管理ダッシュボード' })).toBeVisible();
-    await expect(page.getByText('株式会社テスト').first()).toBeVisible();
+    await expect(page.getByText('株式会社Playwrightモック')).toBeVisible();
 
     // 削除ボタンが初期は無効
-    const deleteBtn = page.getByRole('button', { name: '削除', exact: true }).first();
+    const deleteBtn = page.getByRole('button', { name: '一括削除', exact: true }).first();
     await expect(deleteBtn).toBeDisabled();
 
     // チェックボックスで有効化

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,4 +5,13 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/v1/, '') // sam local はルートでAPIを公開するため /v1 を除去
+      }
+    }
+  }
 })


### PR DESCRIPTION
Closes #27

## 変更内容
- `apiClient.ts` を作成し、S3 Presigned POST、DynamoDB登録・一覧取得・一括削除APIのクライアント関数を実装しました。
- 受付画面 (`ReceptionApp.tsx`) のモック送信処理を実API通信（S3への画像アップロード + DB登録処理）に置き換えました。
- 管理画面 (`AdminApp.tsx`) の一覧表示をDBのデータに基づく形に変更しました。また、1画面で取得・一括削除・画像の個別ダウンロードが可能な構造にリファクタリングしています。ログインについては、当初の「簡易認証で複数人作れるならそれでOK」というご要望に沿い、空パスワード以外の入力を許可する形にしています。
- ローカル開発用に、Vite構成 (`vite.config.ts`) に `/v1` → `http://localhost:3000` へのプロキシ設定を追加しました。
- E2Eテスト (`admin.spec.ts`) の対象URLとデータ照合ロジックを最新のAPI通信仕様に合わせて修正しました。