### PR TITLE
fix: S3 CORS設定の修正と管理画面の画像表示改善

### DIFF
--- a/backend/src/admin/app.js
+++ b/backend/src/admin/app.js
@@ -1,6 +1,7 @@
-import { S3Client, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+import { S3Client, DeleteObjectsCommand, GetObjectCommand } from "@aws-sdk/client-s3";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, QueryCommand, BatchWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const s3Client = new S3Client({});
 const ddbClient = new DynamoDBClient({});
@@ -36,10 +37,29 @@ export const listEntries = async (event) => {
             return !item.expires_at || item.expires_at > nowSeconds;
         });
 
+        const bucketName = process.env.PHOTO_BUCKET_NAME;
+
+        // 画像取得用のPresigned URLを生成
+        const itemsWithPresignedUrl = await Promise.all(activeItems.map(async (item) => {
+            if (item.photo_url) {
+                try {
+                    const command = new GetObjectCommand({
+                        Bucket: bucketName,
+                        Key: item.photo_url
+                    });
+                    const signedUrl = await getSignedUrl(s3Client, command, { expiresIn: 60 * 60 }); // 1時間
+                    item.photo_download_url = signedUrl;
+                } catch (err) {
+                    console.error("Failed to generate presigned URL for", item.photo_url, err);
+                }
+            }
+            return item;
+        }));
+
         return {
             statusCode: 200,
             headers: CORS_HEADERS,
-            body: JSON.stringify(activeItems),
+            body: JSON.stringify(itemsWithPresignedUrl),
         };
 
     } catch (error) {

--- a/backend/src/admin/package-lock.json
+++ b/backend/src/admin/package-lock.json
@@ -10,7 +10,8 @@
             "dependencies": {
                 "@aws-sdk/client-dynamodb": "^3.500.0",
                 "@aws-sdk/client-s3": "^3.500.0",
-                "@aws-sdk/lib-dynamodb": "^3.500.0"
+                "@aws-sdk/lib-dynamodb": "^3.500.0",
+                "@aws-sdk/s3-request-presigner": "^3.1006.0"
             },
             "devDependencies": {
                 "aws-sdk-client-mock": "^4.1.0",
@@ -840,6 +841,25 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@aws-sdk/s3-request-presigner": {
+            "version": "3.1006.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1006.0.tgz",
+            "integrity": "sha512-azZTNllb6zq3hyGvTViBflfN5IeThmSQbYB+JJJqVGB9ZAqV9d6xOUG1BFCtxoKukDT9JnUZqQwQB0Y24gJAPw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/signature-v4-multi-region": "^3.996.7",
+                "@aws-sdk/types": "^3.973.5",
+                "@aws-sdk/util-format-url": "^3.972.7",
+                "@smithy/middleware-endpoint": "^4.4.23",
+                "@smithy/protocol-http": "^5.3.11",
+                "@smithy/smithy-client": "^4.12.3",
+                "@smithy/types": "^4.13.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
             "version": "3.996.7",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.7.tgz",
@@ -925,6 +945,21 @@
                 "@smithy/types": "^4.13.0",
                 "@smithy/url-parser": "^4.2.11",
                 "@smithy/util-endpoints": "^3.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.972.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
+            "integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.5",
+                "@smithy/querystring-builder": "^4.2.11",
+                "@smithy/types": "^4.13.0",
                 "tslib": "^2.6.2"
             },
             "engines": {

--- a/backend/src/admin/package.json
+++ b/backend/src/admin/package.json
@@ -7,7 +7,8 @@
     "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.500.0",
         "@aws-sdk/client-s3": "^3.500.0",
-        "@aws-sdk/lib-dynamodb": "^3.500.0"
+        "@aws-sdk/lib-dynamodb": "^3.500.0",
+        "@aws-sdk/s3-request-presigner": "^3.1006.0"
     },
     "devDependencies": {
         "aws-sdk-client-mock": "^4.1.0",

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -55,6 +55,7 @@ Resources:
             AllowedMethods:
               - PUT
               - GET
+              - POST
             AllowedOrigins:
               - "*" # 本番ではフロントエンドドメインに制限
             ExposedHeaders:
@@ -131,6 +132,8 @@ Resources:
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref EntriesTable
+        - S3ReadPolicy:
+            BucketName: !Ref PhotosBucket
       Events:
         ApiEvent:
           Type: Api

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -29,6 +29,7 @@ export type Entry = {
   purpose: string
   purpose_detail: string
   photo_url: string | null
+  photo_download_url?: string
   expires_at: number
 }
 

--- a/frontend/src/pages/admin/AdminApp.tsx
+++ b/frontend/src/pages/admin/AdminApp.tsx
@@ -354,9 +354,9 @@ export default function AdminApp() {
                     </td>
                     <td className="p-4 text-center">
                       <div className="w-10 h-10 mx-auto rounded bg-gray-100 flex items-center justify-center border border-gray-200 overflow-hidden">
-                        {entry.photo_url ? (
-                          <a href={entry.photo_url} target="_blank" rel="noopener noreferrer" className="w-full h-full block">
-                            <img src={entry.photo_url} alt="Face" className="w-full h-full object-cover hover:opacity-80 transition-opacity" />
+                        {(entry.photo_download_url || entry.photo_url) ? (
+                          <a href={entry.photo_download_url || entry.photo_url || '#'} target="_blank" rel="noopener noreferrer" className="w-full h-full block">
+                            <img src={entry.photo_download_url || entry.photo_url!} alt="Face" className="w-full h-full object-cover hover:opacity-80 transition-opacity" />
                           </a>
                         ) : (
                           <ImageIcon className="w-4 h-4 text-gray-400" />
@@ -385,13 +385,20 @@ export default function AdminApp() {
                       <div className="flex justify-center gap-3">
                         <button 
                           onClick={() => {
-                            if (entry.photo_url) {
-                              const ext = entry.photo_url.split('.').pop() || 'jpg'
+                            const urlStr = entry.photo_download_url || entry.photo_url
+                            if (urlStr) {
+                              let ext = 'jpg';
+                              try {
+                                const parsed = new URL(urlStr)
+                                ext = parsed.pathname.split('.').pop() || 'jpg'
+                              } catch(e) {
+                                ext = urlStr.split('.').pop() || 'jpg'
+                              }
                               const filename = `${entry.company_name}_${entry.visitor_name}_${entry.id.substring(0,6)}.${ext}`
-                              handleDownloadImage(entry.photo_url, filename)
+                              handleDownloadImage(urlStr, filename)
                             }
                           }}
-                          disabled={!entry.photo_url}
+                          disabled={!(entry.photo_download_url || entry.photo_url)}
                           className="text-gray-400 hover:text-[var(--primary)] transition-colors disabled:opacity-30 disabled:hover:text-gray-400" 
                           title="ダウンロード"
                         >


### PR DESCRIPTION
## 変更内容
- S3バケット (`PhotosBucket`) のCORSルールに `POST` メソッドを許可し、受付画面からの画像アップロード時におけるCORSエラーを解消しました。
- 受付画面で登録した画像が管理画面で表示されない問題（S3バケットが非公開のためCloudFrontのデフォルトルーティングで404になる事象）を解決するため、`ListEntriesFunction` 内で `@aws-sdk/s3-request-presigner` を用い、画像の閲覧用URL (`photo_download_url`) を動的に発行するように修正しました。
- それに伴い、`ListEntriesFunction` に `S3ReadPolicy` を付与しました。
- フロントエンドの `AdminApp.tsx` を修正し、発行された Presigned URL を用いて画像プレビューおよびダウンロードを行うように変更しました。

デプロイは完了しており、実環境での動作が確認できる状態になっています。