### PR TITLE
fix: スマホのカメラプレビュー最適化およびデジタルズーム対応

### DIFF
--- a/frontend/src/pages/reception/ReceptionApp.tsx
+++ b/frontend/src/pages/reception/ReceptionApp.tsx
@@ -102,22 +102,31 @@ export default function ReceptionApp() {
       const vWidth = video.videoWidth
       const vHeight = video.videoHeight
 
-      // UIが aspect-square (1:1) で object-cover になっているため、表示されるベースは短い辺に合わせた正方形
-      const minDim = Math.min(vWidth, vHeight)
+      // UIが aspect-[3/4] (縦長) なので、3:4のアスペクト比に合わせてクロップ領域を計算する
+      const targetAspect = 3 / 4
+      let cropWidth, cropHeight
+      
+      if (vWidth / vHeight > targetAspect) {
+        // ビデオが3:4より横長（例: 16:9）の場合、高さが基準
+        cropHeight = vHeight / ZOOM_FACTOR
+        cropWidth = cropHeight * targetAspect
+      } else {
+        // ビデオが3:4より縦長の場合、横が基準
+        cropWidth = vWidth / ZOOM_FACTOR
+        cropHeight = cropWidth / targetAspect
+      }
 
-      // デジタルズーム分をさらにクロップ
-      const cropSize = minDim / ZOOM_FACTOR
-      const sx = (vWidth - cropSize) / 2
-      const sy = (vHeight - cropSize) / 2
+      const sx = (vWidth - cropWidth) / 2
+      const sy = (vHeight - cropHeight) / 2
 
-      // キャンバスを正方形（クロップサイズ）に設定
-      canvas.width = cropSize
-      canvas.height = cropSize
+      // キャンバスを3:4のクロップサイズに設定
+      canvas.width = cropWidth
+      canvas.height = cropHeight
       
       const ctx = canvas.getContext('2d')
       if (ctx) {
-        // 中央部分を切り抜いて正方形で描画
-        ctx.drawImage(video, sx, sy, cropSize, cropSize, 0, 0, cropSize, cropSize)
+        // 中央部分を3:4で切り抜いて描画
+        ctx.drawImage(video, sx, sy, cropWidth, cropHeight, 0, 0, cropWidth, cropHeight)
         
         const photoDataUrl = canvas.toDataURL('image/jpeg', 0.8)
         setPhotoPreview(photoDataUrl)
@@ -245,7 +254,7 @@ export default function ReceptionApp() {
 
               {/* Camera Live View (モバイルのみ) */}
               {isCapturing && !photoPreview && (
-                <div className="relative w-full max-w-sm rounded-lg overflow-hidden bg-black flex flex-col aspect-square">
+                <div className="relative w-full max-w-sm rounded-lg overflow-hidden bg-black flex flex-col aspect-[3/4]">
                   <video 
                     ref={videoRef} 
                     autoPlay 
@@ -268,7 +277,7 @@ export default function ReceptionApp() {
 
               {/* Photo Preview */}
               {photoPreview && (
-                <div className="relative w-full max-w-sm rounded-lg overflow-hidden shadow-md aspect-square">
+                <div className="relative w-full max-w-sm rounded-lg overflow-hidden shadow-md aspect-[3/4]">
                   <img src={photoPreview} alt="Preview" className="w-full h-full object-cover" />
                   <button
                     type="button"


### PR DESCRIPTION
Closes #32

## 変更内容
- スマホ等での極端な画面縮小を防ぐため、カメラプレビューおよびCanvasのキャプチャアスペクト比を `aspect-[3/4]` (縦長) へ見直しました。
- タブレット向けの広角カメラ対策として、1.2倍のデジタルズーム機能（CSS拡大およびCanvasクロップ）を実装しました。
- PCアクセス時の不要な「PCからのアクセスです」メッセージを削除しました。
- PlaywrightのE2Eテストは最新のUI定義に追従しています。