### PR TITLE
fix: 写真バケットの保護設定を明示する

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -59,6 +59,15 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "facereg-photos-${AWS::AccountId}-${AWS::Region}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:
@@ -77,6 +86,27 @@ Resources:
           - Id: AutoDeletePhotosAfter7Days
             Status: Enabled
             ExpirationInDays: 7 # アップロードから7日後に自動削除
+      Tags:
+        - Key: Project
+          Value: facereg-app
+
+  PhotosBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref PhotosBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !GetAtt PhotosBucket.Arn
+              - !Sub "${PhotosBucket.Arn}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   # -------------------------------------------------------------------
   # 3. HTTP API (API Gateway)

--- a/docs/テスト仕様書_Issue38_写真バケット保護設定明示化.md
+++ b/docs/テスト仕様書_Issue38_写真バケット保護設定明示化.md
@@ -1,0 +1,36 @@
+# テスト仕様書: Issue #38 写真バケット保護設定明示化
+
+## 1. 目的
+
+`PhotosBucket` に対して、公開防止・暗号化・TLS 強制の保護設定が SAM テンプレートで明示されていることを確認する。
+
+## 2. 対象
+
+- [backend/template.yaml](/Users/kuninet/git/顔写真登録アプリ/backend/template.yaml)
+
+## 3. 前提条件
+
+- 継続課金を増やさないため、暗号化は追加料金のない SSE-S3 を採用する。
+- 写真バケットは公開配信を前提としない。
+
+## 4. テスト観点
+
+1. `PhotosBucket` に `PublicAccessBlockConfiguration` があること。
+2. `PhotosBucket` に `BucketEncryption` があり、`AES256` が設定されていること。
+3. `PhotosBucketPolicy` で `aws:SecureTransport: false` を拒否していること。
+4. テンプレート全体が `sam validate` を通ること。
+
+## 5. 実行コマンド
+
+```bash
+sam validate --template-file backend/template.yaml
+```
+
+## 6. 期待結果
+
+- `sam validate` が成功する。
+- `PhotosBucket` の保護設定がテンプレート上で読み取れる。
+
+## 7. 今回の結果保存先
+
+- [tmp/test-results/20260314-issue38-photos-bucket-hardening](/Users/kuninet/git/顔写真登録アプリ/tmp/test-results/20260314-issue38-photos-bucket-hardening)


### PR DESCRIPTION
## 概要
- PhotosBucket に PublicAccessBlockConfiguration を追加して公開設定を明示
- PhotosBucket に SSE-S3 の暗号化設定を追加
- TLS なしアクセスを拒否する PhotosBucketPolicy を追加し、テスト仕様書を作成

## テスト
- `sam validate --template-file backend/template.yaml`

## テスト結果保存先
- `tmp/test-results/20260314-issue38-photos-bucket-hardening`

Closes #38