### PR TITLE
fix: API と写真バケットの CORS 許可オリジンを制限する

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -10,3 +10,7 @@ ADMIN_AUTH_CREDENTIALS=admin:strong-password
 # 受付画面の upload_token 署名用秘密値
 # 長くランダムな文字列を設定してください
 UPLOAD_TOKEN_SECRET=replace-with-long-random-secret
+
+# API / 写真バケットからのアクセスを許可するフロントエンド Origin
+# 例: CloudFront URL またはカスタムドメイン
+ALLOWED_CORS_ORIGIN=https://d1234567890abc.cloudfront.net

--- a/backend/src/admin/app.js
+++ b/backend/src/admin/app.js
@@ -7,17 +7,19 @@ const s3Client = new S3Client({});
 const ddbClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(ddbClient);
 
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
+const getCorsHeaders = () => ({
+    "Access-Control-Allow-Origin": process.env.ALLOWED_CORS_ORIGIN || "https://example.invalid",
     "Access-Control-Allow-Headers": "Content-Type",
     "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
-};
+});
 
 /**
  * データベースからのエントリー一覧取得API
  * @param {Object} event HTTP Gateway Event
  */
 export const listEntries = async (event) => {
+    const corsHeaders = getCorsHeaders();
+
     try {
         const tableName = process.env.TABLE_NAME;
 
@@ -58,7 +60,7 @@ export const listEntries = async (event) => {
 
         return {
             statusCode: 200,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify(itemsWithPresignedUrl),
         };
 
@@ -66,7 +68,7 @@ export const listEntries = async (event) => {
         console.error("Error in listEntries", error);
         return {
             statusCode: 500,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({ error: "Failed to fetch entries." }),
         };
     }
@@ -77,6 +79,8 @@ export const listEntries = async (event) => {
  * @param {Object} event HTTP Gateway Event
  */
 export const bulkDelete = async (event) => {
+    const corsHeaders = getCorsHeaders();
+
     try {
         const body = JSON.parse(event.body || "{}");
         const { items } = body;
@@ -84,7 +88,7 @@ export const bulkDelete = async (event) => {
         if (!Array.isArray(items) || items.length === 0) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "Invalid or empty keys for deletion." })
             };
         }
@@ -94,7 +98,7 @@ export const bulkDelete = async (event) => {
         if (requestedIds.length === 0) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "Invalid or empty ids for deletion." })
             };
         }
@@ -102,7 +106,7 @@ export const bulkDelete = async (event) => {
         if (requestedIds.length > 25) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "A maximum of 25 entries can be deleted at once." })
             };
         }
@@ -126,7 +130,7 @@ export const bulkDelete = async (event) => {
         if (resolvedItems.length !== requestedIds.length) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "One or more entries were not found." })
             };
         }
@@ -163,7 +167,7 @@ export const bulkDelete = async (event) => {
 
         return {
             statusCode: 200,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({ message: "Successfully deleted items." }),
         };
 
@@ -171,7 +175,7 @@ export const bulkDelete = async (event) => {
         console.error("Error in bulkDelete", error);
         return {
             statusCode: 500,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({ error: "Failed to delete entries." }),
         };
     }

--- a/backend/src/admin/app.test.js
+++ b/backend/src/admin/app.test.js
@@ -13,6 +13,7 @@ describe('Admin API Tests', () => {
         docMock.reset();
         process.env.TABLE_NAME = 'MockTable';
         process.env.PHOTO_BUCKET_NAME = 'MockBucket';
+        process.env.ALLOWED_CORS_ORIGIN = 'https://admin.example.com';
     });
 
     it('listEntries should return active items and filter out expired items', async () => {
@@ -29,6 +30,7 @@ describe('Admin API Tests', () => {
         const event = {};
         const response = await listEntries(event);
         expect(response.statusCode).toBe(200);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://admin.example.com');
 
         const items = JSON.parse(response.body);
         expect(items.length).toBe(2);
@@ -41,6 +43,7 @@ describe('Admin API Tests', () => {
         };
         const response = await bulkDelete(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://admin.example.com');
     });
 
     it('bulkDelete should resolve photo_url from DynamoDB and delete matched entries only', async () => {
@@ -65,6 +68,7 @@ describe('Admin API Tests', () => {
         };
         const response = await bulkDelete(event);
         expect(response.statusCode).toBe(200);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://admin.example.com');
 
         expect(docMock.calls().length).toBe(2);
         expect(s3Mock.calls().length).toBe(1);
@@ -101,6 +105,7 @@ describe('Admin API Tests', () => {
         };
         const response = await bulkDelete(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://admin.example.com');
         expect(JSON.parse(response.body).error).toContain('not found');
         expect(s3Mock.calls().length).toBe(0);
     });

--- a/backend/src/entries/app.js
+++ b/backend/src/entries/app.js
@@ -8,11 +8,11 @@ const s3Client = new S3Client({});
 const ddbClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(ddbClient);
 
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
+const getCorsHeaders = () => ({
+    "Access-Control-Allow-Origin": process.env.ALLOWED_CORS_ORIGIN || "https://example.invalid",
     "Access-Control-Allow-Headers": "Content-Type",
     "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
-};
+});
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const UPLOAD_TOKEN_TTL_SECONDS = 5 * 60;
@@ -70,6 +70,8 @@ const extractEntryIdFromPhotoKey = (photoKey) => {
  * @param {Object} event HTTP Gateway Event
  */
 export const initializeUpload = async (event) => {
+    const corsHeaders = getCorsHeaders();
+
     try {
         const body = JSON.parse(event.body || "{}");
         const { photo_filename, photo_content_type } = body;
@@ -77,7 +79,7 @@ export const initializeUpload = async (event) => {
         if (!photo_content_type || !ALLOWED_TYPES.includes(photo_content_type)) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "Unsupported or missing Content-Type (Only JPEG, PNG, WEBP are allowed)." }),
             };
         }
@@ -108,7 +110,7 @@ export const initializeUpload = async (event) => {
 
         return {
             statusCode: 200,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({
                 upload_url: url, // フォームのPOST先URL
                 fields: fields,  // フォームに含める追加パラメータ
@@ -123,7 +125,7 @@ export const initializeUpload = async (event) => {
         console.error("Error in initializeUpload", error);
         return {
             statusCode: 500,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({ error: "Failed to generate presigned URL." }),
         };
     }
@@ -134,12 +136,14 @@ export const initializeUpload = async (event) => {
  * @param {Object} event HTTP Gateway Event
  */
 export const registerEntry = async (event) => {
+    const corsHeaders = getCorsHeaders();
+
     try {
         const body = JSON.parse(event.body || "{}");
         const requiredParams = ["company_name", "visitor_name", "purpose", "photo_key", "entry_id", "upload_token"];
         for (const param of requiredParams) {
             if (!body[param]) {
-                return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: `Missing required parameter: ${param}` }) };
+                return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: `Missing required parameter: ${param}` }) };
             }
         }
 
@@ -150,7 +154,7 @@ export const registerEntry = async (event) => {
         if (!extractedEntryId || extractedEntryId !== body.entry_id) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "photo_key does not match entry_id." }),
             };
         }
@@ -162,7 +166,7 @@ export const registerEntry = async (event) => {
         })) {
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "Invalid or expired upload token." }),
             };
         }
@@ -176,7 +180,7 @@ export const registerEntry = async (event) => {
             console.error("Uploaded photo was not found", body.photo_key, error);
             return {
                 statusCode: 400,
-                headers: CORS_HEADERS,
+                headers: corsHeaders,
                 body: JSON.stringify({ error: "Uploaded photo was not found." }),
             };
         }
@@ -211,7 +215,7 @@ export const registerEntry = async (event) => {
 
         return {
             statusCode: 201,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify(item),
         };
 
@@ -219,7 +223,7 @@ export const registerEntry = async (event) => {
         console.error("Error in registerEntry", error);
         return {
             statusCode: 500,
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
             body: JSON.stringify({ error: "Failed to save entry." }),
         };
     }

--- a/backend/src/entries/app.test.js
+++ b/backend/src/entries/app.test.js
@@ -24,6 +24,7 @@ describe('Entries API Tests', () => {
         process.env.TABLE_NAME = 'MockTable';
         process.env.PHOTO_BUCKET_NAME = 'MockBucket';
         process.env.UPLOAD_TOKEN_SECRET = 'test-upload-token-secret';
+        process.env.ALLOWED_CORS_ORIGIN = 'https://app.example.com';
     });
 
     it('initializeUpload should return 400 if Content-Type is invalid', async () => {
@@ -32,6 +33,7 @@ describe('Entries API Tests', () => {
         };
         const response = await initializeUpload(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
         expect(JSON.parse(response.body).error).toContain('Unsupported or missing Content-Type');
     });
 
@@ -41,6 +43,7 @@ describe('Entries API Tests', () => {
         };
         const response = await initializeUpload(event);
         expect(response.statusCode).toBe(200);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
 
         const body = JSON.parse(response.body);
         expect(body.upload_url).toBe('https://mock-presigned-url');
@@ -57,6 +60,7 @@ describe('Entries API Tests', () => {
         };
         const response = await registerEntry(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
     });
 
     it('registerEntry should return 201 and save to DynamoDB for valid payload', async () => {
@@ -80,6 +84,7 @@ describe('Entries API Tests', () => {
         };
         const response = await registerEntry(event);
         expect(response.statusCode).toBe(201);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
 
         const body = JSON.parse(response.body);
         expect(body.pk).toBe('ENTRY');
@@ -104,6 +109,7 @@ describe('Entries API Tests', () => {
 
         const response = await registerEntry(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
         expect(JSON.parse(response.body).error).toContain('Invalid or expired upload token');
     });
 
@@ -128,6 +134,7 @@ describe('Entries API Tests', () => {
 
         const response = await registerEntry(event);
         expect(response.statusCode).toBe(400);
+        expect(response.headers["Access-Control-Allow-Origin"]).toBe('https://app.example.com');
         expect(JSON.parse(response.body).error).toContain('Uploaded photo was not found');
     });
 });

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -13,6 +13,9 @@ Parameters:
     Type: String
     NoEcho: true
     Description: 受付画面のアップロード完了トークン署名に使う秘密値。
+  AllowedCorsOrigin:
+    Type: String
+    Description: API と写真バケットからのアクセスを許可するフロントエンド Origin。
 
 Globals:
   Function:
@@ -24,6 +27,7 @@ Globals:
           TABLE_NAME: !Ref EntriesTable
           PHOTO_BUCKET_NAME: !Ref PhotosBucket
           UPLOAD_TOKEN_SECRET: !Ref UploadTokenSecret
+          ALLOWED_CORS_ORIGIN: !Ref AllowedCorsOrigin
   Api:
     TracingEnabled: false
     # CORS はCloudFront経由の同一オリジンアクセスのため不要
@@ -77,7 +81,7 @@ Resources:
               - GET
               - POST
             AllowedOrigins:
-              - "*" # 本番ではフロントエンドドメインに制限
+              - !Ref AllowedCorsOrigin
             ExposedHeaders:
               - ETag
             MaxAge: 3000

--- a/docs/テスト仕様書_Issue39_CORS制限強化.md
+++ b/docs/テスト仕様書_Issue39_CORS制限強化.md
@@ -1,0 +1,32 @@
+# テスト仕様書: Issue39 CORS 制限強化
+
+## 対象
+
+- [/Users/kuninet/git/顔写真登録アプリ/backend/src/admin/app.js](/Users/kuninet/git/顔写真登録アプリ/backend/src/admin/app.js)
+- [/Users/kuninet/git/顔写真登録アプリ/backend/src/admin/app.test.js](/Users/kuninet/git/顔写真登録アプリ/backend/src/admin/app.test.js)
+- [/Users/kuninet/git/顔写真登録アプリ/backend/src/entries/app.js](/Users/kuninet/git/顔写真登録アプリ/backend/src/entries/app.js)
+- [/Users/kuninet/git/顔写真登録アプリ/backend/src/entries/app.test.js](/Users/kuninet/git/顔写真登録アプリ/backend/src/entries/app.test.js)
+- [/Users/kuninet/git/顔写真登録アプリ/backend/template.yaml](/Users/kuninet/git/顔写真登録アプリ/backend/template.yaml)
+- [/Users/kuninet/git/顔写真登録アプリ/scripts/deploy-backend.sh](/Users/kuninet/git/顔写真登録アプリ/scripts/deploy-backend.sh)
+- [/Users/kuninet/git/顔写真登録アプリ/scripts/test-deploy-backend.sh](/Users/kuninet/git/顔写真登録アプリ/scripts/test-deploy-backend.sh)
+
+## 確認観点
+
+1. API レスポンスの `Access-Control-Allow-Origin` が `*` ではなく、`ALLOWED_CORS_ORIGIN` に一致すること。
+2. 正常系・異常系を問わず同じ CORS ヘッダが返ること。
+3. デプロイスクリプトが `AllowedCorsOrigin` を `sam deploy` に渡すこと。
+4. 写真バケットの `AllowedOrigins` が `AllowedCorsOrigin` Parameter を参照すること。
+
+## 実行コマンド
+
+```bash
+cd backend && npm test
+./scripts/test-deploy-backend.sh
+cd backend && sam validate --template-file template.yaml
+```
+
+## 期待結果
+
+- バックエンドのユニットテストが成功する。
+- デプロイスクリプト回帰テストが成功する。
+- SAM テンプレート検証が成功する。

--- a/docs/デプロイ手順書.md
+++ b/docs/デプロイ手順書.md
@@ -41,7 +41,7 @@ graph LR
 
 ```bash
 cp .env.deploy.example .env.deploy
-# .env.deploy を編集して ADMIN_AUTH_CREDENTIALS と UPLOAD_TOKEN_SECRET を設定
+# .env.deploy を編集して ADMIN_AUTH_CREDENTIALS と UPLOAD_TOKEN_SECRET と ALLOWED_CORS_ORIGIN を設定
 ./scripts/deploy-backend.sh
 ```
 
@@ -51,6 +51,7 @@ cp .env.deploy.example .env.deploy
 - `.env.deploy` — ローカル管理の機密情報ファイルを読み込む。環境変数を明示指定した場合はそちらを優先する
 - `AdminAuthCredentials` — 管理画面API用の Basic 認証情報を `NoEcho` パラメータとして注入
 - `UploadTokenSecret` — 受付画面のアップロード完了トークン署名用秘密値を `NoEcho` パラメータとして注入
+- `AllowedCorsOrigin` — API と写真バケットからのアクセスを許可するフロントエンド Origin を注入
 - 既存 Lambda の未管理ロググループがあれば、CloudFormation 管理へ移行するため先に削除する
 - `AdminAuthorizerFunction` が未作成なら、初回のみ Authorizer 参照を外した一時テンプレートを先にデプロイし、その後に通常テンプレートをデプロイ
 - 完了後、スタック出力値（API URL、CloudFront URL 等）が表示される
@@ -66,6 +67,8 @@ cp .env.deploy.example .env.deploy
 - `aws s3 sync` — ビルド資産を S3 にアップロード
 - `aws cloudfront create-invalidation` — CDN キャッシュクリア
 - 完了後、アクセス URL が表示される
+
+`ALLOWED_CORS_ORIGIN` には、通常このスクリプト完了時に表示される CloudFront URL を設定する。カスタムドメインを使う場合はその Origin を指定する。
 
 ### 3. 動作確認
 

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -11,6 +11,7 @@ DEPLOY_ENV_FILE=".env.deploy"
 
 EXISTING_ADMIN_AUTH_CREDENTIALS="${ADMIN_AUTH_CREDENTIALS:-}"
 EXISTING_UPLOAD_TOKEN_SECRET="${UPLOAD_TOKEN_SECRET:-}"
+EXISTING_ALLOWED_CORS_ORIGIN="${ALLOWED_CORS_ORIGIN:-}"
 
 if [ -f "$DEPLOY_ENV_FILE" ]; then
   set -a
@@ -24,6 +25,10 @@ fi
 
 if [ -n "$EXISTING_UPLOAD_TOKEN_SECRET" ]; then
   UPLOAD_TOKEN_SECRET="$EXISTING_UPLOAD_TOKEN_SECRET"
+fi
+
+if [ -n "$EXISTING_ALLOWED_CORS_ORIGIN" ]; then
+  ALLOWED_CORS_ORIGIN="$EXISTING_ALLOWED_CORS_ORIGIN"
 fi
 
 deploy_stack() {
@@ -42,7 +47,7 @@ deploy_stack() {
     --resolve-s3 \
     --capabilities CAPABILITY_IAM \
     --no-confirm-changeset \
-    --parameter-overrides AdminAuthCredentials="$ADMIN_AUTH_CREDENTIALS" UploadTokenSecret="$UPLOAD_TOKEN_SECRET" \
+    --parameter-overrides AdminAuthCredentials="$ADMIN_AUTH_CREDENTIALS" UploadTokenSecret="$UPLOAD_TOKEN_SECRET" AllowedCorsOrigin="$ALLOWED_CORS_ORIGIN" \
     --tags Project=facereg-app
 }
 
@@ -95,8 +100,8 @@ create_phase1_template() {
   ' template.yaml > "$PHASE1_TEMPLATE"
 }
 
-if [ -z "${ADMIN_AUTH_CREDENTIALS:-}" ] || [ -z "${UPLOAD_TOKEN_SECRET:-}" ]; then
-  echo "${DEPLOY_ENV_FILE} を作成するか、ADMIN_AUTH_CREDENTIALS と UPLOAD_TOKEN_SECRET 環境変数を設定してください。"
+if [ -z "${ADMIN_AUTH_CREDENTIALS:-}" ] || [ -z "${UPLOAD_TOKEN_SECRET:-}" ] || [ -z "${ALLOWED_CORS_ORIGIN:-}" ]; then
+  echo "${DEPLOY_ENV_FILE} を作成するか、ADMIN_AUTH_CREDENTIALS と UPLOAD_TOKEN_SECRET と ALLOWED_CORS_ORIGIN 環境変数を設定してください。"
   echo "例: cp .env.deploy.example .env.deploy"
   exit 1
 fi

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -128,21 +128,22 @@ run_case() {
     TEST_STATE_FILE="$STATE_FILE" \
     ADMIN_AUTH_CREDENTIALS="admin:test-password" \
     UPLOAD_TOKEN_SECRET="test-upload-token-secret" \
+    ALLOWED_CORS_ORIGIN="https://app.example.com" \
     ./scripts/deploy-backend.sh >/dev/null
   )
 
   if [ "$label" = "initial" ]; then
     assert_count "aws logs delete-log-group" 4
     assert_contains "sam build --template-file .codex-bootstrap-admin-auth-template.yaml --build-dir .aws-sam/bootstrap-build"
-    assert_contains "sam deploy --template-file .aws-sam/bootstrap-build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret --tags Project=facereg-app"
+    assert_contains "sam deploy --template-file .aws-sam/bootstrap-build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret AllowedCorsOrigin=https://app.example.com --tags Project=facereg-app"
     assert_contains "sam build --template-file template.yaml --build-dir .aws-sam/build"
-    assert_contains "sam deploy --template-file .aws-sam/build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret --tags Project=facereg-app"
+    assert_contains "sam deploy --template-file .aws-sam/build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret AllowedCorsOrigin=https://app.example.com --tags Project=facereg-app"
     assert_count "sam build" 2
     assert_count "sam deploy" 2
   else
     assert_count "aws logs delete-log-group" 0
     assert_contains "sam build --template-file template.yaml --build-dir .aws-sam/build"
-    assert_contains "sam deploy --template-file .aws-sam/build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret --tags Project=facereg-app"
+    assert_contains "sam deploy --template-file .aws-sam/build/template.yaml --stack-name facereg-app --region ap-northeast-1 --resolve-s3 --capabilities CAPABILITY_IAM --no-confirm-changeset --parameter-overrides AdminAuthCredentials=admin:test-password UploadTokenSecret=test-upload-token-secret AllowedCorsOrigin=https://app.example.com --tags Project=facereg-app"
     assert_count "sam build" 1
     assert_count "sam deploy" 1
   fi


### PR DESCRIPTION
## 概要
- admin / entries Lambda の CORS ヘッダを、デプロイ時に指定する AllowedCorsOrigin の値で返すように変更
- 写真バケットの CORS 設定とバックエンドのデプロイフローにも AllowedCorsOrigin を適用
- 新しいデプロイ変数の説明を追加し、API 応答とデプロイスクリプトの回帰テストを追加

## 検証
- cd backend && npm test
- bash ./scripts/test-deploy-backend.sh
- cd backend && sam validate --template-file template.yaml

Closes #39